### PR TITLE
Remove faulty includes for NONOS 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # why esp8266-json
 
+Updated version of esp8266-json (forked from cJSON) for esp8266-nonos-sdk 2.1.0.
+
+
 ## Welcome to esp8266-json!
 As the json library included in ESP8266 SDK is very difficult to use for me, 
 so I created this project modified from cjson.

--- a/cJSON.c
+++ b/cJSON.c
@@ -22,10 +22,8 @@
 
 /* cJSON */
 /* JSON parser in C. */
-#include "esp_systemapi.h"
 #include "ets_sys.h"
 #include "osapi.h"
-#include "uart.h"
 #include "mem.h"
 
 #include "cJSON.h"


### PR DESCRIPTION
With NONOS 2.1.0, esp_systemapi.h and uart.h are not requiered